### PR TITLE
Use batch_single_subject.sh from SCT repo

### DIFF
--- a/.github/workflows/run_script_and_create_release.yml
+++ b/.github/workflows/run_script_and_create_release.yml
@@ -53,8 +53,9 @@ jobs:
         ref: ${{ env.GITHUB_SHA }}
         path: ${{ github.event.repository.name }}
 
-    - name: Run batch_single_subject.sh to generate intermediate files
+    - name: Copy and run batch_single_subject.sh to generate intermediate files
       run: |
+        cp spinalcordtoolbox/batch_single_subject.sh "${{ github.event.repository.name }}/single_subject"
         cd "${{ github.event.repository.name }}/single_subject"
         ./batch_single_subject.sh
 
@@ -63,12 +64,25 @@ jobs:
         cd ${{ github.event.repository.name }}
         awk -F, '{ print $1,$2 }' tutorial-datasets.csv | xargs -l zip -ur
 
+    # We commit the upstream changes to batch_single_subject.sh only after
+    # tutorial datasets are successfully created
+    - name: Commit new changes to batch_single_subject.sh
+      run: |
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "GitHub Actions Bot"
+        git add "${{ github.event.repository.name }}/single_subject/batch_single_subject.sh"
+        git commit -m "Update batch_single_subject.sh for ${{ github.event.inputs.release_title }}"
+        git push
+        echo "HEAD_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      # Only update batch_single_subject.sh if workflow is run manually. (This allows the workflow to double as a PR test.)
+      if: github.event_name == 'workflow_dispatch'
+
     - uses: ncipollo/release-action@v1
       name: Create release ('${{ github.event.inputs.release_title }}')
       id: create_release
       with:
         tag: ${{ github.event.inputs.release_title }}
-        commit: ${{ env.GITHUB_SHA }}
+        commit: ${{ env.HEAD_SHA }}
         token: ${{ secrets.GITHUB_TOKEN }}
       # Only create release if workflow is run manually. (This allows the workflow to double as a PR test.)
       if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/run_script_and_create_release.yml
+++ b/.github/workflows/run_script_and_create_release.yml
@@ -32,6 +32,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: spinalcordtoolbox/spinalcordtoolbox
+        ref: jn/3508-copy-batch_single_subject.sh
         path: spinalcordtoolbox
 
     # install_sct edits ~/.bashrc, but those environment changes don't get passed to subsequent steps in GH Actions.


### PR DESCRIPTION
## Description

This PR is meant to be used in tandem with the [`jn/3508-copy-batch-single-subject.sh`](https://github.com/spinalcordtoolbox/spinalcordtoolbox/tree/jn/3508-copy-batch_single_subject.sh) branch on SCT, and together, they change how we update batch_single_subject.sh. 

- Now, the "main copy" of the script will be stored in the SCT repo, and will be updated with SCT PRs. 
- Over in this repo, we'll only update the script when we make a new release. 
- And, we'll only ever create a new release _if the data files themselves_ change, or if we're preparing for a new course.
   - The reason for this is because, from the perspective of the SCT tutorials, the individual `.zip` files will contain the same data files regardless of `batch_single_subject.sh`. 

This will reduce the number of releases we'll need to create, since many changes don't involve the data files themselves changing.

## Related PRs/Issues

https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3508