### PR TITLE
Upgrade node12 actions

### DIFF
--- a/.github/workflows/run_batch_script.yml
+++ b/.github/workflows/run_batch_script.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
     - name: Checkout spinalcordtoolbox
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: spinalcordtoolbox/spinalcordtoolbox
         path: spinalcordtoolbox
@@ -41,7 +41,7 @@ jobs:
         cat ~/.bashrc | grep "export PATH" | grep -o "/.*" | cut -d ':' -f 1 >> $GITHUB_PATH
 
     - name: "Checkout '${{ github.event.repository.name }}'"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: ${{ github.event.repository.name }}
 

--- a/.github/workflows/run_script_and_create_release.yml
+++ b/.github/workflows/run_script_and_create_release.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
 
     - name: Checkout spinalcordtoolbox
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: spinalcordtoolbox/spinalcordtoolbox
         path: spinalcordtoolbox
@@ -47,7 +47,7 @@ jobs:
         cat ~/.bashrc | grep "export PATH" | grep -o "/.*" | cut -d ':' -f 1 >> $GITHUB_PATH
 
     - name: "Checkout '${{ github.event.repository.name }}'"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ env.GITHUB_SHA }}
         path: ${{ github.event.repository.name }}


### PR DESCRIPTION
To address the following warning from Github Actions:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/