### PR TITLE
Add data and commands for `rootlets-segmentation` tutorial 

### DIFF
--- a/single_subject/batch_single_subject.sh
+++ b/single_subject/batch_single_subject.sh
@@ -130,6 +130,19 @@ fsleyes t2.nii.gz -cm greyscale t2_sc_seg.nii.gz -cm red -a 70.0 t2_lesion_seg.n
 # Compute various morphometric measures, such as number of lesions, lesion length, lesion volume, etc.
 sct_analyze_lesion -m t2_lesion_seg.nii.gz -s t2_sc_seg.nii.gz -qc ~/qc_singleSubj
 
+
+
+# Rootlets segmentation
+# ======================================================================================================================
+cd ../t2
+# Segment the spinal nerve rootlets
+sct_deepseg -i t2.nii.gz -task seg_spinal_rootlets_t2w -qc ~/qc_singleSubj
+
+# Check results using Fsleyes
+fsleyes t2.nii.gz -cm greyscale t2_seg.nii.gz -cm subcortical -a 70.0 &
+
+
+
 # Registering T2 data to the PAM50 template
 # ======================================================================================================================
 cd ../t2

--- a/tutorial-datasets.csv
+++ b/tutorial-datasets.csv
@@ -41,6 +41,7 @@ data_processing-fmri-data,single_subject/data/fmri/fmri.nii.gz
 data_processing-fmri-data,single_subject/data/t2/t2.nii.gz
 data_processing-fmri-data,single_subject/data/t2s/warp_template2t2s.nii.gz
 data_processing-fmri-data,single_subject/data/t2s/warp_t2s2template.nii.gz
+data_rootlets-segmentation,single_subject/data/t2/t2.nii.gz
 data_spinalcord-smoothing,single_subject/data/t1/t1.nii.gz
 data_spinalcord-smoothing,single_subject/data/t1/t1_seg.nii.gz
 data_visualizing-misaligned-cords,single_subject/data/t1/t1.nii.gz


### PR DESCRIPTION
Changes originally by @valosekj.

PR opened because it makes it easier to create a new release for the `lesion-analysis` tutorial (to help make the SCT diffs clearer).