### PR TITLE
Automatically upload CSV files as artifacts during CI runs

### DIFF
--- a/.github/workflows/run_batch_script.yml
+++ b/.github/workflows/run_batch_script.yml
@@ -50,6 +50,12 @@ jobs:
         cd "${{ github.event.repository.name }}/multi_subject"
         sct_run_batch -script process_data.sh -config config.yml
 
+    - name: "Upload CSV files for easier tutorial updating"
+      uses: actions/upload-artifact@v4
+      with:
+        name: Multi Subject CSV Files
+        path: multi_subject/output/**/*.csv
+
     - name: Output full log for sanity checking
       run: |
         cd "${{ github.event.repository.name }}/multi_subject/output/log"

--- a/.github/workflows/run_script_and_create_release.yml
+++ b/.github/workflows/run_script_and_create_release.yml
@@ -60,6 +60,12 @@ jobs:
         cd "${{ github.event.repository.name }}/single_subject"
         ./batch_single_subject.sh
 
+    - name: "Upload CSV files for easier tutorial updating"
+      uses: actions/upload-artifact@v4
+      with:
+        name: Single Subject CSV Files
+        path: single_subject/data/**/*.csv
+
     - name: "Package data into tutorial-specific .zip files"
       run: |
         cd ${{ github.event.repository.name }}


### PR DESCRIPTION
This should make it easier to update sample values in the tutorials.

I could go even further and write a little script that postprocesses the CSV files so that they match the "nice to display" format we use for the tutorials?

Needed for https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/5012.